### PR TITLE
Add the possibility to have several maps on the same page

### DIFF
--- a/_includes/map.html
+++ b/_includes/map.html
@@ -28,37 +28,35 @@
 
 	{% if include.showmap and include.location.geo %}
 	<div class="col-md-9">
-			<link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" integrity="sha512-M2wvCLH6DSRazYeZRIm1JnYyh22purTM+FDB5CsyxtQJYeKq83arPe5wgbNmcFXGqiSH2XR8dT/fJISVA1r/zQ==" crossorigin=""/>
-			<script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet.js" integrity="sha512-lInM/apFSqyy1o6s89K4iQUKg6ppXEgsVxT35HbzUupEVRh2Eu9Wdl4tHj7dZO0s1uvplcYGmt3498TtHq+log==" crossorigin=""></script>
-			<div id="mapid" style='height: 180px;'></div>
-			<script type="text/javascript">
-				var map = L.map('mapid').setView([
-					{{ include.location.geo.lat }},
-					{{ include.location.geo.lon }}
-				], {% if include.zoomlevel %}{{ include.zoomlevel }}{% else %}9{% endif %});
+		<div id="mapid_{{ include.location.name }}" style='height: 180px;'></div>
+		<script type="text/javascript">
+			var map = L.map('mapid_{{ include.location.name }}').setView([
+				{{ include.location.geo.lat }},
+				{{ include.location.geo.lon }}
+			], {% if include.zoomlevel %}{{ include.zoomlevel }}{% else %}9{% endif %});
 
-				L.tileLayer('https://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-					attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
-				}).addTo(map);
+			L.tileLayer('https://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+				attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
+			}).addTo(map);
 
-				var parts = [
-					"{{ include.location.name }}",
-					"{{ include.location.street }}",
-					"{{ include.location.city }}",
-					"{{ include.location.region }}",
-					"{{ include.location.country }}",
-				].filter(function(x){ return x !== "" });
+			var parts = [
+				"{{ include.location.name }}",
+				"{{ include.location.street }}",
+				"{{ include.location.city }}",
+				"{{ include.location.region }}",
+				"{{ include.location.country }}",
+			].filter(function(x){ return x !== "" });
 
-				L.marker([
-					{{ include.location.geo.lat }},
-					{{ include.location.geo.lon }}
-				]).addTo(map)
-				{% if include.hidepopup %}
-				{% else %}
-					.bindPopup(parts.join(",<br>"))
-				{% endif %}
-					.openPopup();
-			</script>
+			L.marker([
+				{{ include.location.geo.lat }},
+				{{ include.location.geo.lon }}
+			]).addTo(map)
+			{% if include.hidepopup %}
+			{% else %}
+				.bindPopup(parts.join(",<br>"))
+			{% endif %}
+				.openPopup();
+		</script>
     </div>
 	{% endif %}
 	</div>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -14,6 +14,8 @@
         <link href="{{ site.baseurl }}/assets/css/theme.css" rel="stylesheet">
         <link href="{{ site.baseurl }}/assets/css/custom.css" rel="stylesheet">
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.1/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" integrity="sha512-M2wvCLH6DSRazYeZRIm1JnYyh22purTM+FDB5CsyxtQJYeKq83arPe5wgbNmcFXGqiSH2XR8dT/fJISVA1r/zQ==" crossorigin=""/>
+        <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet.js" integrity="sha512-lInM/apFSqyy1o6s89K4iQUKg6ppXEgsVxT35HbzUupEVRh2Eu9Wdl4tHj7dZO0s1uvplcYGmt3498TtHq+log==" crossorigin=""></script>
 
         {{ site.sharethis }}
 


### PR DESCRIPTION
As @fpsom identified, only one map was displayed on the event page.
To have several maps, each map should have its own `div` with its own `id` ([found on stackoverflow](https://stackoverflow.com/questions/25293579/multiple-leaflet-maps-on-same-page-with-same-options)). So I used the location name to make individual div with id